### PR TITLE
Tiling composite exposes num_tiles

### DIFF
--- a/dwave_micro_client_dimod/tiling.py
+++ b/dwave_micro_client_dimod/tiling.py
@@ -149,6 +149,10 @@ class TilingComposite(dimod.TemplateComposite):
 
         return source_response
 
+    @property
+    def num_tiles(self):
+        return len(self.embeddings)
+
 
 def draw_tiling(sampler, t=4):
     """Draw Chimera graph of sampler with colored tiles.


### PR DESCRIPTION
Todo - add an example in the documentation for

```
def batch_sample_qubo(Qlist, sampler, num_samples):
    if hasattr(sampler, 'num_tiles'):
        num_reads = -(-num_samples // sampler.num_tiles)
    else:
        num_reads = num_samples

    return [sampler.sample_qubo(Q, num_reads=num_reads) for Q in Qlist]
```